### PR TITLE
Update to Dojo 6.0.0-alpha and Tweak to Image Styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,225 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+			"dev": true,
+			"requires": {
+				"@babel/highlight": "^7.0.0"
+			}
+		},
+		"@babel/core": {
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.5.tgz",
+			"integrity": "sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.4.4",
+				"@babel/helpers": "^7.4.4",
+				"@babel/parser": "^7.4.5",
+				"@babel/template": "^7.4.4",
+				"@babel/traverse": "^7.4.5",
+				"@babel/types": "^7.4.4",
+				"convert-source-map": "^1.1.0",
+				"debug": "^4.1.0",
+				"json5": "^2.1.0",
+				"lodash": "^4.17.11",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"json5": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+					"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+			"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.4.4",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.11",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+			"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.4.4"
+			}
+		},
+		"@babel/helpers": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
+			"integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.4.4",
+				"@babel/traverse": "^7.4.4",
+				"@babel/types": "^7.4.4"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
+			},
+			"dependencies": {
+				"js-tokens": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/parser": {
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+			"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+			"dev": true
+		},
+		"@babel/template": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+			"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.4.4",
+				"@babel/types": "^7.4.4"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+			"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.4.4",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.4.4",
+				"@babel/parser": "^7.4.5",
+				"@babel/types": "^7.4.4",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.11"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/types": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+			"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+			"dev": true,
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.11",
+				"to-fast-properties": "^2.0.0"
+			},
+			"dependencies": {
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
 		"@csstools/convert-colors": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
@@ -55,16 +274,17 @@
 			}
 		},
 		"@dojo/cli-build-app": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@dojo/cli-build-app/-/cli-build-app-5.0.4.tgz",
-			"integrity": "sha512-YZdU9zbxEEYjfaMHZRFOhnkodfq0EBwG2TWE0grH7ashhADFISYsAXZVRxgApOAWLnbUO51LFlTt0qLHbb2mLQ==",
+			"version": "6.0.0-alpha.1",
+			"resolved": "https://registry.npmjs.org/@dojo/cli-build-app/-/cli-build-app-6.0.0-alpha.1.tgz",
+			"integrity": "sha512-5wxIL0Zfqj8e//EfMd4ctqp+vFoKq9vc1NL//UTZGSINFMZyNLC+Xuqn07mdpkJVfCnjcnl7JpjQb0+fwss+og==",
 			"dev": true,
 			"requires": {
-				"@dojo/webpack-contrib": "^5.0.0",
+				"@dojo/webpack-contrib": "6.0.0-alpha.2",
 				"brotli-webpack-plugin": "1.0.0",
 				"chalk": "2.4.1",
 				"clean-webpack-plugin": "1.0.0",
 				"cli-columns": "3.1.2",
+				"compression": "1.7.4",
 				"compression-webpack-plugin": "2.0.0",
 				"connect-history-api-fallback": "1.5.0",
 				"connect-inject": "0.4.0",
@@ -89,6 +309,7 @@
 				"log-symbols": "2.1.0",
 				"log-update": "2.3.0",
 				"mini-css-extract-plugin": "0.4.2",
+				"minimatch": "3.0.4",
 				"optimize-css-assets-webpack-plugin": "5.0.1",
 				"ora": "1.3.0",
 				"pkg-dir": "2.0.0",
@@ -98,6 +319,8 @@
 				"slash": "1.0.0",
 				"source-map-loader-cli": "0.0.1",
 				"strip-ansi": "3.0.1",
+				"stylelint": "9.10.1",
+				"stylelint-webpack-plugin": "0.10.5",
 				"terser-webpack-plugin": "1.1.0",
 				"ts-loader": "5.3.0",
 				"ts-node": "7.0.1",
@@ -162,6 +385,27 @@
 				"typescript": "~2.6.1"
 			},
 			"dependencies": {
+				"@dojo/framework": {
+					"version": "5.0.4",
+					"resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-5.0.4.tgz",
+					"integrity": "sha512-E8y+E6k6VgVOCiTQqokFEmxODuL4p6b7BroiGo5DNEgmS9dRMMHsO6UadDHx/TOsw47vP56Ly+ugHZbpS/XcWg==",
+					"dev": true,
+					"requires": {
+						"@types/cldrjs": "0.4.20",
+						"@types/globalize": "0.0.34",
+						"@webcomponents/webcomponentsjs": "1.1.0",
+						"cldrjs": "0.5.0",
+						"css-select-umd": "1.3.0-rc0",
+						"diff": "3.5.0",
+						"globalize": "1.4.0",
+						"intersection-observer": "0.4.2",
+						"pepjs": "0.4.2",
+						"resize-observer-polyfill": "1.5.0",
+						"tslib": "1.8.1",
+						"web-animations-js": "2.3.1",
+						"whatwg-fetch": "3.0.0"
+					}
+				},
 				"cross-spawn": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
@@ -224,6 +468,12 @@
 						"yn": "^2.0.0"
 					}
 				},
+				"tslib": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+					"integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw=",
+					"dev": true
+				},
 				"typescript": {
 					"version": "2.6.2",
 					"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
@@ -233,23 +483,24 @@
 			}
 		},
 		"@dojo/framework": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-5.0.4.tgz",
-			"integrity": "sha512-E8y+E6k6VgVOCiTQqokFEmxODuL4p6b7BroiGo5DNEgmS9dRMMHsO6UadDHx/TOsw47vP56Ly+ugHZbpS/XcWg==",
+			"version": "6.0.0-alpha.1",
+			"resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-6.0.0-alpha.1.tgz",
+			"integrity": "sha512-/tPwqHqmYImAOymGOZ/d65tQt7zZJ9Vy8r6Uwdm6edplmmkygryIVuRjKj7SN+2VsLdexXlnwJ9y+/CZNzBCOA==",
 			"requires": {
 				"@types/cldrjs": "0.4.20",
 				"@types/globalize": "0.0.34",
 				"@webcomponents/webcomponentsjs": "1.1.0",
 				"cldrjs": "0.5.0",
+				"cross-fetch": "3.0.2",
 				"css-select-umd": "1.3.0-rc0",
 				"diff": "3.5.0",
 				"globalize": "1.4.0",
+				"immutable": "3.8.2",
 				"intersection-observer": "0.4.2",
 				"pepjs": "0.4.2",
 				"resize-observer-polyfill": "1.5.0",
 				"tslib": "1.8.1",
-				"web-animations-js": "2.3.1",
-				"whatwg-fetch": "3.0.0"
+				"web-animations-js": "2.3.1"
 			},
 			"dependencies": {
 				"tslib": {
@@ -265,16 +516,17 @@
 			"integrity": "sha512-Ph/mQ3FZAV+ioVVrc/f3Sq4dOKFJ4cDMYYXI+CJbdOOpoRc9ydgOyONaAOBI5o56VJHnO5CrvFp6cLt83O3GnQ=="
 		},
 		"@dojo/webpack-contrib": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-5.0.3.tgz",
-			"integrity": "sha512-X2wI2TDNwGBmxk6C9wujZhwfF37mezBzZ0hliiVNACRuDtocyakpJri6cl1Ct8CnTEWxscIrVJPRGoKkNi00Rg==",
+			"version": "6.0.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-6.0.0-alpha.2.tgz",
+			"integrity": "sha512-3l6W1EMFnSTYQ41pucAqMWbiBJZk4VkcnXiGQoZdxPpY3DEi7Cb/sObOMpXzPSMs4ND/VqswuFh8U0it1bbnNw==",
 			"dev": true,
 			"requires": {
-				"@dojo/framework": "^5.0.0",
+				"@dojo/framework": "6.0.0-alpha.1",
 				"acorn": "5.3.0",
 				"acorn-dynamic-import": "3.0.0",
 				"bfj": "6.1.1",
 				"chalk": "2.3.0",
+				"clear-module": "3.1.0",
 				"commander": "2.13.0",
 				"connect-history-api-fallback": "1.6.0",
 				"copy-webpack-plugin": "4.6.0",
@@ -290,6 +542,7 @@
 				"istanbul-lib-instrument": "1.10.1",
 				"loader-utils": "1.1.0",
 				"lodash": "4.17.4",
+				"minimatch": "3.0.4",
 				"mkdirp": "0.5.1",
 				"node-html-parser": "1.1.11",
 				"opener": "1.4.3",
@@ -298,6 +551,7 @@
 				"recast": "0.12.7",
 				"source-map": "0.6.1",
 				"ts-loader": "5.3.0",
+				"ts-node": "^8.0.3",
 				"typed-css-modules": "0.3.7",
 				"webpack-hot-middleware": "2.24.3",
 				"workbox-webpack-plugin": "3.6.3",
@@ -349,6 +603,12 @@
 					"version": "1.6.0",
 					"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
 					"integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+					"dev": true
+				},
+				"diff": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+					"integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
 					"dev": true
 				},
 				"fs-extra": {
@@ -464,6 +724,19 @@
 						"has-flag": "^2.0.0"
 					}
 				},
+				"ts-node": {
+					"version": "8.2.0",
+					"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.2.0.tgz",
+					"integrity": "sha512-m8XQwUurkbYqXrKqr3WHCW310utRNvV5OnRVeISeea7LoCWVcdfeB/Ntl8JYWFh+WRoUAdBgESrzKochQt7sMw==",
+					"dev": true,
+					"requires": {
+						"arg": "^4.1.0",
+						"diff": "^4.0.1",
+						"make-error": "^1.1.1",
+						"source-map-support": "^0.5.6",
+						"yn": "^3.0.0"
+					}
+				},
 				"typed-css-modules": {
 					"version": "0.3.7",
 					"resolved": "https://registry.npmjs.org/typed-css-modules/-/typed-css-modules-0.3.7.tgz",
@@ -515,6 +788,12 @@
 					"requires": {
 						"camelcase": "^4.1.0"
 					}
+				},
+				"yn": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
+					"integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==",
+					"dev": true
 				}
 			}
 		},
@@ -543,6 +822,22 @@
 				"refractor": "^2.3.0",
 				"unist-util-visit": "^1.1.3"
 			}
+		},
+		"@mrmlnc/readdir-enhanced": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+			"dev": true,
+			"requires": {
+				"call-me-maybe": "^1.0.1",
+				"glob-to-regexp": "^0.3.0"
+			}
+		},
+		"@nodelib/fs.stat": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+			"dev": true
 		},
 		"@theintern/common": {
 			"version": "0.1.4",
@@ -679,6 +974,17 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/glob": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+			"dev": true,
+			"requires": {
+				"@types/events": "*",
+				"@types/minimatch": "*",
+				"@types/node": "*"
+			}
+		},
 		"@types/globalize": {
 			"version": "0.0.34",
 			"resolved": "https://registry.npmjs.org/@types/globalize/-/globalize-0.0.34.tgz",
@@ -737,6 +1043,12 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
 			"integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
+			"dev": true
+		},
+		"@types/minimatch": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
 			"dev": true
 		},
 		"@types/node": {
@@ -828,9 +1140,9 @@
 			}
 		},
 		"@types/webpack": {
-			"version": "4.4.31",
-			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.4.31.tgz",
-			"integrity": "sha512-WNALmv/wxy2+OoF7A5GD8BVotXnkuMHlojVWKj/neFHU3Ut2Azbu1A7Yi2Vr6eX3z+31XgR/dJ5NpX4pQZ7ieQ==",
+			"version": "4.4.32",
+			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.4.32.tgz",
+			"integrity": "sha512-mNARoaSJTzbiHxtZbf9NULFilu2frqD+g9Iyl9V2jPYJWXi+AC3Hz8lQWPZ5LLtgUm7iF4SDDMB/1bPrbRQgFw==",
 			"dev": true,
 			"requires": {
 				"@types/anymatch": "*",
@@ -1235,11 +1547,16 @@
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
 			}
+		},
+		"arg": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+			"integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+			"dev": true
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -1400,6 +1717,12 @@
 			"version": "0.9.12",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.12.tgz",
 			"integrity": "sha1-sTYwDWcCZiWuFTJpgsqZGOXbc8k=",
+			"dev": true
+		},
+		"astral-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
 			"dev": true
 		},
 		"async": {
@@ -2045,14 +2368,14 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.0.tgz",
-			"integrity": "sha512-Jk0YFwXBuMOOol8n6FhgkDzn3mY9PYLYGk29zybF05SbRTsMgPqmTNeQQhOghCxq5oFqAXE3u4sYddr4C0uRhg==",
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.1.tgz",
+			"integrity": "sha512-1MC18ooMPRG2UuVFJTHFIAkk6mpByJfxCrnUyvSlu/hyQSFHMrlhM02SzNuCV+quTP4CKmqtOMAIjrifrpBJXQ==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30000967",
-				"electron-to-chromium": "^1.3.133",
-				"node-releases": "^1.1.19"
+				"caniuse-lite": "^1.0.30000971",
+				"electron-to-chromium": "^1.3.137",
+				"node-releases": "^1.1.21"
 			}
 		},
 		"buffer": {
@@ -2192,6 +2515,12 @@
 				"unset-value": "^1.0.0"
 			}
 		},
+		"call-me-maybe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+			"dev": true
+		},
 		"caller-callsite": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -2199,6 +2528,14 @@
 			"dev": true,
 			"requires": {
 				"callsites": "^2.0.0"
+			},
+			"dependencies": {
+				"callsites": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+					"dev": true
+				}
 			}
 		},
 		"caller-path": {
@@ -2211,9 +2548,9 @@
 			}
 		},
 		"callsites": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true
 		},
 		"camel-case": {
@@ -2263,9 +2600,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000969",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000969.tgz",
-			"integrity": "sha512-Kus0yxkoAJgVc0bax7S4gLSlFifCa7MnSZL9p9VuS/HIKEL4seaqh28KIQAAO50cD/rJ5CiJkJFapkdDAlhFxQ==",
+			"version": "1.0.30000971",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000971.tgz",
+			"integrity": "sha512-TQFYFhRS0O5rdsmSbF1Wn+16latXYsQJat66f7S7lizXW1PVpWJeZw9wqqVLIjuxDRz7s7xRUj13QCfd8hKn6g==",
 			"dev": true
 		},
 		"canonical-path": {
@@ -2284,6 +2621,12 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
+		},
+		"ccount": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
+			"integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==",
 			"dev": true
 		},
 		"chai": {
@@ -2315,6 +2658,12 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
 			"integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w==",
+			"dev": true
+		},
+		"character-entities-html4": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.3.tgz",
+			"integrity": "sha512-SwnyZ7jQBCRHELk9zf2CN5AnGEc2nA+uKMZLHvcqhpPprjkYhiLn0DywMHgN5ttFZuITMATbh68M6VIVKwJbcg==",
 			"dev": true
 		},
 		"character-entities-legacy": {
@@ -2383,9 +2732,9 @@
 			"dev": true
 		},
 		"chrome-trace-event": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
-			"integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
+			"integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
@@ -2451,6 +2800,16 @@
 			"dev": true,
 			"requires": {
 				"rimraf": "^2.6.1"
+			}
+		},
+		"clear-module": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/clear-module/-/clear-module-3.1.0.tgz",
+			"integrity": "sha512-YEe9OX62MYUMjw16Vf2txyzZ3x2ICXNOrjuZ+06MMhnx3fy7V121h9VA3M3bMTtDg8oEfQ2f/fLuhxrSLXS8uw==",
+			"dev": true,
+			"requires": {
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
 			}
 		},
 		"cli-boxes": {
@@ -2528,6 +2887,16 @@
 				"string-width": "^2.1.1",
 				"strip-ansi": "^4.0.0",
 				"wrap-ansi": "^2.0.0"
+			}
+		},
+		"clone-regexp": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
+			"integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
+			"dev": true,
+			"requires": {
+				"is-regexp": "^1.0.0",
+				"is-supported-regexp-flag": "^1.0.0"
 			}
 		},
 		"co": {
@@ -2658,6 +3027,47 @@
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
 			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
 			"dev": true
+		},
+		"compressible": {
+			"version": "2.0.17",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
+			"integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
+			"dev": true,
+			"requires": {
+				"mime-db": ">= 1.40.0 < 2"
+			}
+		},
+		"compression": {
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+			"integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+			"dev": true,
+			"requires": {
+				"accepts": "~1.3.5",
+				"bytes": "3.0.0",
+				"compressible": "~2.0.16",
+				"debug": "2.6.9",
+				"on-headers": "~1.0.2",
+				"safe-buffer": "5.1.2",
+				"vary": "~1.1.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
 		},
 		"compression-webpack-plugin": {
 			"version": "2.0.0",
@@ -2811,8 +3221,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"console-polyfill": {
 			"version": "0.1.2",
@@ -3051,6 +3460,15 @@
 				"ripemd160": "^2.0.0",
 				"safe-buffer": "^5.0.1",
 				"sha.js": "^2.4.8"
+			}
+		},
+		"cross-fetch": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.2.tgz",
+			"integrity": "sha512-a4Z0EJ5Nck6QtMy9ZqloLfpvu2uMV3sBfMCR+CgSBCZc6z5KR4bfEiD3dkepH8iZgJMXQpTqf8FjMmvu/GMFkg==",
+			"requires": {
+				"node-fetch": "2.3.0",
+				"whatwg-fetch": "3.0.0"
 			}
 		},
 		"cross-spawn": {
@@ -3584,6 +4002,16 @@
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
+		"decamelize-keys": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+			"dev": true,
+			"requires": {
+				"decamelize": "^1.1.0",
+				"map-obj": "^1.0.0"
+			}
+		},
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -3829,8 +4257,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -3873,8 +4300,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"diff": {
 			"version": "3.5.0",
@@ -4028,9 +4454,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.135",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.135.tgz",
-			"integrity": "sha512-xXLNstRdVsisPF3pL3H9TVZo2XkMILfqtD6RiWIUmDK2sFX1Bjwqmd8LBp0Kuo2FgKO63JXPoEVGm8WyYdwP0Q==",
+			"version": "1.3.137",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.137.tgz",
+			"integrity": "sha512-kGi32g42a8vS/WnYE7ELJyejRT7hbr3UeOOu0WeuYuQ29gCpg9Lrf6RdcTQVXSt/v0bjCfnlb/EWOOsiKpTmkw==",
 			"dev": true
 		},
 		"elliptic": {
@@ -4381,6 +4807,15 @@
 					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 					"dev": true
 				}
+			}
+		},
+		"execall": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
+			"integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
+			"dev": true,
+			"requires": {
+				"clone-regexp": "^1.0.0"
 			}
 		},
 		"exif-parser": {
@@ -4735,6 +5170,20 @@
 			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
 			"dev": true
 		},
+		"fast-glob": {
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+			"integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+			"dev": true,
+			"requires": {
+				"@mrmlnc/readdir-enhanced": "^2.2.1",
+				"@nodelib/fs.stat": "^1.1.2",
+				"glob-parent": "^3.1.0",
+				"is-glob": "^4.0.0",
+				"merge2": "^1.2.3",
+				"micromatch": "^3.1.10"
+			}
+		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -4784,6 +5233,15 @@
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
+			}
+		},
+		"file-entry-cache": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-4.0.0.tgz",
+			"integrity": "sha512-AVSwsnbV8vH/UVbvgEhf3saVQXORNv0ZzSkvkhQIaia5Tia+JhGTaa/ePUSVoPHQyGayQNmYfkzFi3WZV5zcpA==",
+			"dev": true,
+			"requires": {
+				"flat-cache": "^2.0.1"
 			}
 		},
 		"file-loader": {
@@ -5137,6 +5595,23 @@
 				"locate-path": "^2.0.0"
 			}
 		},
+		"flat-cache": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+			"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+			"dev": true,
+			"requires": {
+				"flatted": "^2.0.0",
+				"rimraf": "2.6.3",
+				"write": "1.0.3"
+			}
+		},
+		"flatted": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+			"integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+			"dev": true
+		},
 		"flatten": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
@@ -5306,8 +5781,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -5328,14 +5802,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -5350,20 +5822,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -5480,8 +5949,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -5493,7 +5961,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5508,7 +5975,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -5516,14 +5982,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -5542,7 +6006,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -5623,8 +6086,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -5636,7 +6098,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -5722,8 +6183,7 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -5759,7 +6219,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -5779,7 +6238,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -5823,14 +6281,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -5845,7 +6301,6 @@
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"aproba": "^1.0.3",
 				"console-control-strings": "^1.0.0",
@@ -5861,15 +6316,13 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5879,7 +6332,6 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -5891,7 +6343,6 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -6095,6 +6546,26 @@
 				"ini": "^1.3.4"
 			}
 		},
+		"global-modules": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+			"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+			"dev": true,
+			"requires": {
+				"global-prefix": "^3.0.0"
+			}
+		},
+		"global-prefix": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+			"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+			"dev": true,
+			"requires": {
+				"ini": "^1.3.5",
+				"kind-of": "^6.0.2",
+				"which": "^1.3.1"
+			}
+		},
 		"globalize": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/globalize/-/globalize-1.4.0.tgz",
@@ -6126,6 +6597,29 @@
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
+				}
+			}
+		},
+		"globjoin": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+			"integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
+			"dev": true
+		},
+		"gonzales-pe": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.4.tgz",
+			"integrity": "sha512-v0Ts/8IsSbh9n1OJRnSfa7Nlxi4AkXIsWB6vPept8FDbL4bXn3FNuxjYtO/nmBGu7GDkL9MFeGebeSu6l55EPQ==",
+			"dev": true,
+			"requires": {
+				"minimist": "1.1.x"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+					"integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
 					"dev": true
 				}
 			}
@@ -6264,8 +6758,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -6494,6 +6987,12 @@
 				}
 			}
 		},
+		"html-tags": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
+			"integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=",
+			"dev": true
+		},
 		"html-webpack-include-assets-plugin": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/html-webpack-include-assets-plugin/-/html-webpack-include-assets-plugin-1.0.6.tgz",
@@ -6557,9 +7056,9 @@
 			},
 			"dependencies": {
 				"readable-stream": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-					"integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
@@ -6748,6 +7247,11 @@
 			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
 			"dev": true
 		},
+		"immutable": {
+			"version": "3.8.2",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+			"integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
+		},
 		"import-cwd": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
@@ -6765,6 +7269,14 @@
 			"requires": {
 				"caller-path": "^2.0.0",
 				"resolve-from": "^3.0.0"
+			},
+			"dependencies": {
+				"resolve-from": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+					"dev": true
+				}
 			}
 		},
 		"import-from": {
@@ -6774,6 +7286,14 @@
 			"dev": true,
 			"requires": {
 				"resolve-from": "^3.0.0"
+			},
+			"dependencies": {
+				"resolve-from": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+					"dev": true
+				}
 			}
 		},
 		"import-lazy": {
@@ -7189,6 +7709,12 @@
 			"integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA==",
 			"dev": true
 		},
+		"is-alphanumeric": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
+			"integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ=",
+			"dev": true
+		},
 		"is-alphanumerical": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
@@ -7496,6 +8022,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
+		},
+		"is-supported-regexp-flag": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
+			"integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
 			"dev": true
 		},
 		"is-svg": {
@@ -7987,6 +8519,12 @@
 			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
 			"dev": true
 		},
+		"known-css-properties": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.11.0.tgz",
+			"integrity": "sha512-bEZlJzXo5V/ApNNa5z375mJC6Nrz4vG43UgcSCrg2OHC+yuB6j0iDSrY7RQ/+PRofFB03wNIIt9iXIVLr4wc7w==",
+			"dev": true
+		},
 		"last-call-webpack-plugin": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz",
@@ -8019,6 +8557,12 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
 			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+			"dev": true
+		},
+		"leven": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
 			"dev": true
 		},
 		"levn": {
@@ -8209,6 +8753,12 @@
 				}
 			}
 		},
+		"longest-streak": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.3.tgz",
+			"integrity": "sha512-9lz5IVdpwsKLMzQi0MQ+oD9EA0mIGcWYP7jXMTZVXP8D42PwuAk+M/HBFYQoxt1G5OR8m7aSIgb1UymfWGBWEw==",
+			"dev": true
+		},
 		"loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -8311,10 +8861,22 @@
 			"integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw==",
 			"dev": true
 		},
+		"markdown-table": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
+			"integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
+			"dev": true
+		},
 		"math-random": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
 			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+			"dev": true
+		},
+		"mathml-tag-names": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.1.tgz",
+			"integrity": "sha512-pWB896KPGSGkp1XtyzRBftpTzwSOL0Gfk0wLvxt4f2mgzjY19o0LxJ3U25vNWTzsh7da+KTbuXQoQ3lOJZ8WHw==",
 			"dev": true
 		},
 		"md5.js": {
@@ -8326,6 +8888,15 @@
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.1.2"
+			}
+		},
+		"mdast-util-compact": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.3.tgz",
+			"integrity": "sha512-nRiU5GpNy62rZppDKbLwhhtw5DXoFMqw9UNZFmlPsNaQCZ//WLjGKUwWMdJrUH+Se7UvtO2gXtAMe0g/N+eI5w==",
+			"dev": true,
+			"requires": {
+				"unist-util-visit": "^1.1.0"
 			}
 		},
 		"mdast-util-definitions": {
@@ -8423,6 +8994,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
 			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+			"dev": true
+		},
+		"merge2": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
+			"integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==",
 			"dev": true
 		},
 		"methods": {
@@ -8542,6 +9119,16 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 			"dev": true
+		},
+		"minimist-options": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+			"dev": true,
+			"requires": {
+				"arrify": "^1.0.1",
+				"is-plain-obj": "^1.1.0"
+			}
 		},
 		"mississippi": {
 			"version": "3.0.0",
@@ -8694,6 +9281,11 @@
 				"semver": "^5.4.1"
 			}
 		},
+		"node-fetch": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+			"integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+		},
 		"node-fetch-npm": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
@@ -8754,9 +9346,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.19",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.19.tgz",
-			"integrity": "sha512-SH/B4WwovHbulIALsQllAVwqZZD1kPmKCqrhGfR29dXjLAVZMHvBjD3S6nL9D/J9QkmZ1R92/0wCMDKXUUvyyA==",
+			"version": "1.1.21",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.21.tgz",
+			"integrity": "sha512-TwnURTCjc8a+ElJUjmDqU6+12jhli1Q61xOQmdZ7ECZVBZuQpN/1UnembiIHDM1wCcfLvh5wrWXUF5H6ufX64Q==",
 			"dev": true,
 			"requires": {
 				"semver": "^5.3.0"
@@ -8797,6 +9389,12 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
 			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+			"dev": true
+		},
+		"normalize-selector": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
+			"integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
 			"dev": true
 		},
 		"normalize-url": {
@@ -8845,7 +9443,6 @@
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -8985,6 +9582,12 @@
 			"requires": {
 				"ee-first": "1.1.1"
 			}
+		},
+		"on-headers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+			"integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+			"dev": true
 		},
 		"once": {
 			"version": "1.4.0",
@@ -9220,6 +9823,15 @@
 			"dev": true,
 			"requires": {
 				"no-case": "^2.2.0"
+			}
+		},
+		"parent-module": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"dev": true,
+			"requires": {
+				"callsites": "^3.0.0"
 			}
 		},
 		"parse-asn1": {
@@ -9979,6 +10591,15 @@
 				}
 			}
 		},
+		"postcss-html": {
+			"version": "0.36.0",
+			"resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.36.0.tgz",
+			"integrity": "sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==",
+			"dev": true,
+			"requires": {
+				"htmlparser2": "^3.10.0"
+			}
+		},
 		"postcss-image-set-function": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-2.0.0.tgz",
@@ -10037,6 +10658,15 @@
 				}
 			}
 		},
+		"postcss-jsx": {
+			"version": "0.36.0",
+			"resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.0.tgz",
+			"integrity": "sha512-/lWOSXSX5jlITCKFkuYU2WLFdrncZmjSVyNpHAunEgirZXLwI8RjU556e3Uz4mv0WVHnJA9d3JWb36lK9Yx99g==",
+			"dev": true,
+			"requires": {
+				"@babel/core": ">=7.1.0"
+			}
+		},
 		"postcss-lab-function": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-1.1.0.tgz",
@@ -10057,6 +10687,59 @@
 						"chalk": "^2.4.1",
 						"source-map": "^0.6.1",
 						"supports-color": "^5.4.0"
+					}
+				}
+			}
+		},
+		"postcss-less": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.4.tgz",
+			"integrity": "sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.14"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -10119,6 +10802,16 @@
 				}
 			}
 		},
+		"postcss-markdown": {
+			"version": "0.36.0",
+			"resolved": "https://registry.npmjs.org/postcss-markdown/-/postcss-markdown-0.36.0.tgz",
+			"integrity": "sha512-rl7fs1r/LNSB2bWRhyZ+lM/0bwKv9fhl38/06gF6mKMo/NPnp55+K1dSTosSVjFZc0e1ppBlu+WT91ba0PMBfQ==",
+			"dev": true,
+			"requires": {
+				"remark": "^10.0.1",
+				"unist-util-find-all-after": "^1.0.2"
+			}
+		},
 		"postcss-media-minmax": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-3.0.0.tgz",
@@ -10140,6 +10833,12 @@
 					}
 				}
 			}
+		},
+		"postcss-media-query-parser": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+			"integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
+			"dev": true
 		},
 		"postcss-merge-longhand": {
 			"version": "4.0.11",
@@ -10726,6 +11425,63 @@
 				}
 			}
 		},
+		"postcss-reporter": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.1.tgz",
+			"integrity": "sha512-LpmQjfRWyabc+fRygxZjpRxfhRf9u/fdlKf4VHG4TSPbV2XNsuISzYW1KL+1aQzx53CAppa1bKG4APIB/DOXXw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.1",
+				"lodash": "^4.17.11",
+				"log-symbols": "^2.2.0",
+				"postcss": "^7.0.7"
+			},
+			"dependencies": {
+				"log-symbols": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+					"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1"
+					}
+				}
+			}
+		},
+		"postcss-resolve-nested-selector": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+			"integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
+			"dev": true
+		},
+		"postcss-safe-parser": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.1.tgz",
+			"integrity": "sha512-xZsFA3uX8MO3yAda03QrG3/Eg1LN3EPfjjf07vke/46HERLZyHrTsQ9E1r1w1W//fWEhtYNndo2hQplN2cVpCQ==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.0"
+			}
+		},
+		"postcss-sass": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.3.5.tgz",
+			"integrity": "sha512-B5z2Kob4xBxFjcufFnhQ2HqJQ2y/Zs/ic5EZbCywCkxKd756Q40cIQ/veRDwSrw1BF6+4wUgmpm0sBASqVi65A==",
+			"dev": true,
+			"requires": {
+				"gonzales-pe": "^4.2.3",
+				"postcss": "^7.0.1"
+			}
+		},
+		"postcss-scss": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.0.0.tgz",
+			"integrity": "sha512-um9zdGKaDZirMm+kZFKKVsnKPF7zF7qBAtIfTSnZXD1jZ0JNZIxdB6TxQOjCnlSzLRInVl2v3YdBh/M881C4ug==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.0"
+			}
+		},
 		"postcss-selector-matches": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-3.0.1.tgz",
@@ -10806,6 +11562,12 @@
 				"postcss-value-parser": "^3.0.0",
 				"svgo": "^1.0.0"
 			}
+		},
+		"postcss-syntax": {
+			"version": "0.36.2",
+			"resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
+			"integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
+			"dev": true
 		},
 		"postcss-unique-selectors": {
 			"version": "4.0.1",
@@ -11114,6 +11876,18 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+			"dev": true
+		},
+		"quick-lru": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+			"dev": true
+		},
+		"ramda": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
+			"integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==",
 			"dev": true
 		},
 		"randomatic": {
@@ -11487,6 +12261,17 @@
 			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
 			"dev": true
 		},
+		"remark": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/remark/-/remark-10.0.1.tgz",
+			"integrity": "sha512-E6lMuoLIy2TyiokHprMjcWNJ5UxfGQjaMSMhV+f4idM625UjjK4j798+gPs5mfjzDE6vL0oFKVeZM6gZVSVrzQ==",
+			"dev": true,
+			"requires": {
+				"remark-parse": "^6.0.0",
+				"remark-stringify": "^6.0.0",
+				"unified": "^7.0.0"
+			}
+		},
 		"remark-external-links": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/remark-external-links/-/remark-external-links-4.0.0.tgz",
@@ -11555,6 +12340,28 @@
 			"dev": true,
 			"requires": {
 				"mdast-util-to-hast": "^4.0.0"
+			}
+		},
+		"remark-stringify": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-6.0.4.tgz",
+			"integrity": "sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==",
+			"dev": true,
+			"requires": {
+				"ccount": "^1.0.0",
+				"is-alphanumeric": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-whitespace-character": "^1.0.0",
+				"longest-streak": "^2.0.1",
+				"markdown-escapes": "^1.0.0",
+				"markdown-table": "^1.1.0",
+				"mdast-util-compact": "^1.0.0",
+				"parse-entities": "^1.0.2",
+				"repeat-string": "^1.5.4",
+				"state-toggle": "^1.0.0",
+				"stringify-entities": "^1.0.1",
+				"unherit": "^1.0.4",
+				"xtend": "^4.0.1"
 			}
 		},
 		"remove-trailing-separator": {
@@ -11733,9 +12540,9 @@
 			}
 		},
 		"resolve-from": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true
 		},
 		"resolve-url": {
@@ -12386,6 +13193,12 @@
 			"integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
 			"dev": true
 		},
+		"specificity": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
+			"integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
+			"dev": true
+		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -12556,6 +13369,18 @@
 				"safe-buffer": "~5.1.0"
 			}
 		},
+		"stringify-entities": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
+			"integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
+			"dev": true,
+			"requires": {
+				"character-entities-html4": "^1.0.0",
+				"character-entities-legacy": "^1.0.0",
+				"is-alphanumerical": "^1.0.0",
+				"is-hexadecimal": "^1.0.0"
+			}
+		},
 		"stringify-object": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
@@ -12633,6 +13458,12 @@
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 			"dev": true
 		},
+		"style-search": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+			"integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
+			"dev": true
+		},
 		"style-to-object": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.2.2.tgz",
@@ -12666,6 +13497,366 @@
 				}
 			}
 		},
+		"stylelint": {
+			"version": "9.10.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.10.1.tgz",
+			"integrity": "sha512-9UiHxZhOAHEgeQ7oLGwrwoDR8vclBKlSX7r4fH0iuu0SfPwFaLkb1c7Q2j1cqg9P7IDXeAV2TvQML/fRQzGBBQ==",
+			"dev": true,
+			"requires": {
+				"autoprefixer": "^9.0.0",
+				"balanced-match": "^1.0.0",
+				"chalk": "^2.4.1",
+				"cosmiconfig": "^5.0.0",
+				"debug": "^4.0.0",
+				"execall": "^1.0.0",
+				"file-entry-cache": "^4.0.0",
+				"get-stdin": "^6.0.0",
+				"global-modules": "^2.0.0",
+				"globby": "^9.0.0",
+				"globjoin": "^0.1.4",
+				"html-tags": "^2.0.0",
+				"ignore": "^5.0.4",
+				"import-lazy": "^3.1.0",
+				"imurmurhash": "^0.1.4",
+				"known-css-properties": "^0.11.0",
+				"leven": "^2.1.0",
+				"lodash": "^4.17.4",
+				"log-symbols": "^2.0.0",
+				"mathml-tag-names": "^2.0.1",
+				"meow": "^5.0.0",
+				"micromatch": "^3.1.10",
+				"normalize-selector": "^0.2.0",
+				"pify": "^4.0.0",
+				"postcss": "^7.0.13",
+				"postcss-html": "^0.36.0",
+				"postcss-jsx": "^0.36.0",
+				"postcss-less": "^3.1.0",
+				"postcss-markdown": "^0.36.0",
+				"postcss-media-query-parser": "^0.2.3",
+				"postcss-reporter": "^6.0.0",
+				"postcss-resolve-nested-selector": "^0.1.1",
+				"postcss-safe-parser": "^4.0.0",
+				"postcss-sass": "^0.3.5",
+				"postcss-scss": "^2.0.0",
+				"postcss-selector-parser": "^3.1.0",
+				"postcss-syntax": "^0.36.2",
+				"postcss-value-parser": "^3.3.0",
+				"resolve-from": "^4.0.0",
+				"signal-exit": "^3.0.2",
+				"slash": "^2.0.0",
+				"specificity": "^0.4.1",
+				"string-width": "^3.0.0",
+				"style-search": "^0.1.0",
+				"sugarss": "^2.0.0",
+				"svg-tags": "^1.0.0",
+				"table": "^5.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"autoprefixer": {
+					"version": "9.5.1",
+					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.5.1.tgz",
+					"integrity": "sha512-KJSzkStUl3wP0D5sdMlP82Q52JLy5+atf2MHAre48+ckWkXgixmfHyWmA77wFDy6jTHU6mIgXv6hAQ2mf1PjJQ==",
+					"dev": true,
+					"requires": {
+						"browserslist": "^4.5.4",
+						"caniuse-lite": "^1.0.30000957",
+						"normalize-range": "^0.1.2",
+						"num2fraction": "^1.2.2",
+						"postcss": "^7.0.14",
+						"postcss-value-parser": "^3.3.1"
+					}
+				},
+				"camelcase-keys": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+					"dev": true,
+					"requires": {
+						"camelcase": "^4.1.0",
+						"map-obj": "^2.0.0",
+						"quick-lru": "^1.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"emoji-regex": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+					"dev": true
+				},
+				"get-stdin": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+					"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+					"dev": true
+				},
+				"globby": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+					"integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+					"dev": true,
+					"requires": {
+						"@types/glob": "^7.1.1",
+						"array-union": "^1.0.2",
+						"dir-glob": "^2.2.2",
+						"fast-glob": "^2.2.6",
+						"glob": "^7.1.3",
+						"ignore": "^4.0.3",
+						"pify": "^4.0.1",
+						"slash": "^2.0.0"
+					},
+					"dependencies": {
+						"ignore": {
+							"version": "4.0.6",
+							"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+							"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+							"dev": true
+						}
+					}
+				},
+				"ignore": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
+					"integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
+					"dev": true
+				},
+				"import-lazy": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
+					"integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==",
+					"dev": true
+				},
+				"indent-string": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+					"dev": true
+				},
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+							"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+							"dev": true
+						}
+					}
+				},
+				"map-obj": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+					"dev": true
+				},
+				"meow": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+					"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+					"dev": true,
+					"requires": {
+						"camelcase-keys": "^4.0.0",
+						"decamelize-keys": "^1.0.0",
+						"loud-rejection": "^1.0.0",
+						"minimist-options": "^3.0.1",
+						"normalize-package-data": "^2.3.4",
+						"read-pkg-up": "^3.0.0",
+						"redent": "^2.0.0",
+						"trim-newlines": "^2.0.0",
+						"yargs-parser": "^10.0.0"
+					}
+				},
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+					"dev": true
+				},
+				"postcss": {
+					"version": "7.0.16",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+					"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.4.2",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							},
+							"dependencies": {
+								"supports-color": {
+									"version": "5.5.0",
+									"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+									"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+									"dev": true,
+									"requires": {
+										"has-flag": "^3.0.0"
+									}
+								}
+							}
+						}
+					}
+				},
+				"postcss-selector-parser": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+					"dev": true,
+					"requires": {
+						"dot-prop": "^4.1.1",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
+					}
+				},
+				"read-pkg": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+					"dev": true,
+					"requires": {
+						"find-up": "^2.0.0",
+						"read-pkg": "^3.0.0"
+					}
+				},
+				"redent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+					"dev": true,
+					"requires": {
+						"indent-string": "^3.0.0",
+						"strip-indent": "^2.0.0"
+					}
+				},
+				"slash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"dev": true
+				},
+				"strip-indent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"trim-newlines": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+					"dev": true
+				},
+				"yargs-parser": {
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^4.1.0"
+					}
+				}
+			}
+		},
+		"stylelint-webpack-plugin": {
+			"version": "0.10.5",
+			"resolved": "https://registry.npmjs.org/stylelint-webpack-plugin/-/stylelint-webpack-plugin-0.10.5.tgz",
+			"integrity": "sha512-jtYx3aJ2qDMvBMswe5NRPTO7kJgAKafc6GilAkWDp/ewoAmnoxA6TsYMnIPtLECRLwXevaCPvlh2JEUMGZCoUQ==",
+			"dev": true,
+			"requires": {
+				"arrify": "^1.0.1",
+				"micromatch": "^3.1.8",
+				"object-assign": "^4.1.0",
+				"ramda": "^0.25.0"
+			}
+		},
+		"sugarss": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
+			"integrity": "sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.2"
+			}
+		},
 		"supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -12674,6 +13865,12 @@
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
+		},
+		"svg-tags": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+			"integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
+			"dev": true
 		},
 		"svgo": {
 			"version": "1.2.2",
@@ -12702,6 +13899,63 @@
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
 			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
 			"dev": true
+		},
+		"table": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/table/-/table-5.4.0.tgz",
+			"integrity": "sha512-nHFDrxmbrkU7JAFKqKbDJXfzrX2UBsWmrieXFTGxiI5e4ncg3VqsZeI4EzNmX0ncp4XNGVeoxIWJXfCIXwrsvw==",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.9.1",
+				"lodash": "^4.17.11",
+				"slice-ansi": "^2.1.0",
+				"string-width": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+					"dev": true
+				},
+				"slice-ansi": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+					"integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"astral-regex": "^1.0.0",
+						"is-fullwidth-code-point": "^2.0.0"
+					}
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
+			}
 		},
 		"tapable": {
 			"version": "1.1.3",
@@ -13571,6 +14825,16 @@
 				"typography-breakpoint-constants": "^0.16.19"
 			}
 		},
+		"uglify-es": {
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+			"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+			"dev": true,
+			"requires": {
+				"commander": "~2.13.0",
+				"source-map": "~0.6.1"
+			}
+		},
 		"uglify-js": {
 			"version": "3.4.10",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
@@ -13671,16 +14935,6 @@
 					"dev": true,
 					"requires": {
 						"safe-buffer": "^5.1.1"
-					}
-				},
-				"uglify-es": {
-					"version": "3.3.9",
-					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-					"dev": true,
-					"requires": {
-						"commander": "~2.13.0",
-						"source-map": "~0.6.1"
 					}
 				}
 			}
@@ -13859,6 +15113,15 @@
 			"dev": true,
 			"requires": {
 				"object-assign": "^4.1.0"
+			}
+		},
+		"unist-util-find-all-after": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.3.tgz",
+			"integrity": "sha512-FNPM5Q1AViItYvkLngkalxZ879j842VxGzlfI0gLlgDQz/Teh9CUzqpc7kgFOWO3RK5qU/wqG0UnJ6XWiHSWiA==",
+			"dev": true,
+			"requires": {
+				"unist-util-is": "^2.0.0"
 			}
 		},
 		"unist-util-generated": {
@@ -14438,15 +15701,13 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
 			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"wide-align": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
 			}
@@ -14704,6 +15965,15 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
+		},
+		"write": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+			"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+			"dev": true,
+			"requires": {
+				"mkdirp": "^0.5.1"
+			}
 		},
 		"write-file-atomic": {
 			"version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"test:all": "dojo build --mode unit && dojo build --mode functional && dojo test --all --config local"
 	},
 	"dependencies": {
-		"@dojo/framework": "^5.0.0",
+		"@dojo/framework": "6.0.0-alpha.1",
 		"@dojo/themes": "^5.0.0",
 		"@dojo/widgets": "^5.0.0",
 		"tslib": "~1.9.3",
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {
 		"@dojo/cli": "^5.0.0",
-		"@dojo/cli-build-app": "^5.0.0",
+		"@dojo/cli-build-app": "6.0.0-alpha.1",
 		"@dojo/cli-test-intern": "^5.0.0",
 		"@mapbox/rehype-prism": "^0.3.1",
 		"@types/fs-extra": "^7.0.0",

--- a/src/widgets/card/Card.m.css
+++ b/src/widgets/card/Card.m.css
@@ -12,6 +12,7 @@
 	max-height: 175px;
 	width: 100%;
 	height: 100%;
+	object-fit: contain;
 }
 
 @media only screen and (max-width: 480px) {


### PR DESCRIPTION
A couple of small changes:

 * Update `@dojo/framework` to `6.0.0-alpha.1`
   * There are various fixes for BTR and Dojo Blocks coming in 6.0.0 and this reduces the `Blog` bundle from `5.5mb` uncompressed/`276kb` compressed to `778kb` uncompressed / `89kb` compressed.
 * Update `@dojo/cli-build-app` to `6.0.0-alpha.1`
   * `@dojo/framework` has a fix that pauses hydration/merging on initial load when a lazy widget is loading so that you will not longer get the weird content flash 
 * Adds `object-fit: contain;` to the image class to help with the strange stretching

Another observation is the typography.js doesn't play nicely with BTR as the style tag is programatically injected meaning that you notice a flash of un-styled content before the styles are loaded.

Ps Awesome stuff!!!! 😄 