### PR TITLE
Re-organise the blog list so that it does not run every blog's block

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { tsx, create } from '@dojo/framework/core/vdom';
 import Outlet from '@dojo/framework/routing/Outlet';
 
 import Blog from './pages/Blog';
+import BlogList from './blog-list/BlogList';
 
 import Layout from './layouts/Layout';
 
@@ -18,9 +19,9 @@ export default factory(({ properties }) => {
         renderer={(matchDetails) => {
           const { params } = matchDetails;
           if (params.path && params.path !== '') {
-            return <Blog standalone path={params.path} />;
+            return <Blog path={params.path} />;
           }
-          return <Blog />;
+          return <BlogList />;
         }}
       />
     </Layout>

--- a/src/blocks/compile-blog-index.block.ts
+++ b/src/blocks/compile-blog-index.block.ts
@@ -17,7 +17,6 @@ export default async function(options: any) {
 			blogs.push({
 				sortDate: new Date(`${meta.date}`),
 				file,
-				// content,
 				meta
 			});
 		}

--- a/src/blocks/compile-blog-index.block.ts
+++ b/src/blocks/compile-blog-index.block.ts
@@ -17,7 +17,7 @@ export default async function(options: any) {
 			blogs.push({
 				sortDate: new Date(`${meta.date}`),
 				file,
-				content,
+				// content,
 				meta
 			});
 		}

--- a/src/blog-list/BlogList.tsx
+++ b/src/blog-list/BlogList.tsx
@@ -1,0 +1,17 @@
+import { tsx, create } from '@dojo/framework/core/vdom';
+import block from '@dojo/framework/core/middleware/block';
+
+import Card from '../widgets/card/Card';
+import compileBlogIndex from '../blocks/compile-blog-index.block';
+
+const factory = create({ block });
+
+export default factory(({ middleware: { block } }) => {
+    const blogs = block(compileBlogIndex)({}) || [];
+    console.warn(blogs);
+    return (
+        <virtual>
+            {blogs.map((blog) => <Card key={blog.file} path={blog.file} {...blog.meta} />)}
+        </virtual>
+    );
+});

--- a/src/blog-list/BlogList.tsx
+++ b/src/blog-list/BlogList.tsx
@@ -8,7 +8,6 @@ const factory = create({ block });
 
 export default factory(({ middleware: { block } }) => {
     const blogs = block(compileBlogIndex)({}) || [];
-    console.warn(blogs);
     return (
         <virtual>
             {blogs.map((blog) => <Card key={blog.file} path={blog.file} {...blog.meta} />)}

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,31 +1,16 @@
 import { tsx, create } from '@dojo/framework/core/vdom';
-import block from '@dojo/framework/core/middleware/block';
-
-
-import compileBlogIndex from '../blocks/compile-blog-index.block';
-
 import Post from '../templates/blog-post/BlogPost';
 
 import * as css from './Blog.m.css';
 
-const factory = create({ block }).properties<{ standalone?: boolean; path?: string }>();
+const factory = create().properties<{ path: string }>();
 
-export default factory(({ middleware: { block }, properties }) => {
-  const { standalone = false, path } = properties();
-  const blogs: any = block(compileBlogIndex)({});
+export default factory(({ properties }) => {
+  const { path } = properties();
 
   return (
     <div classes={[ css.root ]}>
-      {!standalone ? (
-        blogs &&
-        blogs.map((blog: any) => [
-          <Post key={blog.file} path={blog.file} excerpt />,
-          <hr key={blog.file} />
-        ])
-      ) : (
-        undefined
-      )}
-      {path && path.length && <Post key={path} path={path} />}
+      <Post key={path} path={path} />
     </div>
   );
 });

--- a/src/templates/blog-post/BlogPost.tsx
+++ b/src/templates/blog-post/BlogPost.tsx
@@ -6,19 +6,17 @@ import Link from '@dojo/framework/routing/Link';
 import compileBlogPost from '../../blocks/compile-blog-post.block';
 
 import Article from '../../widgets/article/Article';
-import Card from '../../widgets/card/Card';
 
 import { dateFormatter } from '../../utils/formatter';
 
 export interface PostProperties {
-	excerpt?: boolean;
 	path: string;
 }
 
 const factory = create({ block }).properties<PostProperties>();
 
 export default factory(({ middleware: { block }, properties }) => {
-  let { excerpt = false, path }  = properties();
+  let { path }  = properties();
   if (!path.includes('.md')) {
     path = `${path}.md`;
   }
@@ -28,12 +26,9 @@ export default factory(({ middleware: { block }, properties }) => {
 
   if (post) {
     const date = dateFormatter(new Date(post.meta.date));
-    if (excerpt) {
-      return <Card path={path} {...post.meta} />;
-    }
     return (
       <section>
-        {!excerpt && <img src={post.meta.cover_image} />}
+        <img src={post.meta.cover_image} />
         <Article key={post.meta.title}>
           <Link
             to="blog"


### PR DESCRIPTION
I noticed that going to the home page was loading every blog's block. Additionally the index blog block included the `content` which was never used and unnecessarily bloated the size.

This introduces a new widget for the blog index (`BlogList`) and as such doesn't run the block for each individual blog.

### Before Lighthouse

<img width="783" alt="DevTools_-_localhost_5000_" src="https://user-images.githubusercontent.com/1982678/65997476-5b05ac00-e491-11e9-9c4a-fddc37f7f3a8.png">

### After Lighthouse

<img width="776" alt="DevTools_-_localhost_5000_" src="https://user-images.githubusercontent.com/1982678/65997488-6062f680-e491-11e9-85d4-6a4004563377.png">

I had a look to try and make sure everything else was still working, but it might be worth checking before merging (if you want to merge at all 😄 )
